### PR TITLE
Removing eper from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 RELEASE := skyline
 COOKIE  := node_runner
-APPS    := web amqp_client avz cowboy erlydtl gproc kai kvs lager mimetypes mqs n2o oauth rabbit_common ranch sync eper
+APPS    := web amqp_client avz cowboy erlydtl gproc kai kvs lager mimetypes mqs n2o oauth rabbit_common ranch sync
 VER     := 1.0.0
 VM      := rels/web/files/vm.args
 SYS     := rels/web/files/sys.config


### PR DESCRIPTION
Should have been removed at commit a3ab79bb12fa30049867a201249f6c69593dfaaa

closes #31
